### PR TITLE
Add niceIncrement option on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,13 @@ This class extends [`EventEmitter`][] from Node.js.
     for details. Unlike regular Node.js Worker Threads, `workerData` must not
     specify any value requiring a `transferList`. This is because the `workerData`
     will be cloned for each pooled worker.
-  * `taskQueue` : (`TaskQueue`) By default, Piscina uses a first-in-first-out
+  * `taskQueue`: (`TaskQueue`) By default, Piscina uses a first-in-first-out
     queue for submitted tasks. The `taskQueue` option can be used to provide an
     alternative implementation. See [Custom Task Queues][] for additional detail.
+  * `niceIncrement`: (`number`) An optional value that decreases priority for
+    the individual threads, i.e. the higher the value, the lower the priority
+    of the Worker threads. This value is only used on Linux.
+    See [`nice(2)`][] for more details.
 
 Use caution when setting resource limits. Setting limits that are too low may
 result in the `Piscina` worker threads being unusable.
@@ -697,6 +701,7 @@ Piscina development is sponsored by [NearForm Research][].
 [`EventEmitter`]: https://nodejs.org/api/events.html
 [`postMessage`]: https://nodejs.org/api/worker_threads.html#worker_threads_port_postmessage_value_transferlist
 [`examples/task-queue`]: https://github.com/jasnell/piscina/blob/master/examples/task-queue/index.js
+[`nice(2)`]: https://linux.die.net/man/2/nice
 [Custom Task Queues]: #custom_task_queues
 [ES modules]: https://nodejs.org/api/esm.html
 [Node.js new Worker options]: https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "plugins": [
       "@typescript-eslint/eslint-plugin"
     ]
+  },
+  "optionalDependencies": {
+    "nice-napi": "^1.0.2"
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,6 +5,7 @@ export interface StartupMessage {
   port : MessagePort;
   sharedBuffer : Int32Array;
   useAtomics : boolean;
+  niceIncrement : number;
 }
 
 export interface RequestMessage {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -68,8 +68,16 @@ async function getHandler (filename : string) : Promise<Function | null> {
 // (so we can pre-load and cache the handler).
 parentPort!.on('message', (message : StartupMessage) => {
   useAtomics = message.useAtomics;
-  const { port, sharedBuffer, filename } = message;
+  const { port, sharedBuffer, filename, niceIncrement } = message;
   (async function () {
+    try {
+      if (niceIncrement !== 0 && process.platform === 'linux') {
+        // ts-ignore because the dependency is not installed on Windows.
+        // @ts-ignore
+        (await import('nice-napi')).default(niceIncrement);
+      }
+    } catch {}
+
     if (filename !== null) {
       await getHandler(filename);
     }

--- a/test/nice.ts
+++ b/test/nice.ts
@@ -1,0 +1,31 @@
+import Piscina from '..';
+import { resolve } from 'path';
+import { test } from 'tap';
+
+test('can set niceness for threads on Linux', {
+  skip: process.platform !== 'linux'
+}, async ({ is }) => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    niceIncrement: 5
+  });
+
+  // ts-ignore because the dependency is not installed on Windows.
+  // @ts-ignore
+  const currentNiceness = (await import('nice-napi')).default(0);
+  const result = await worker.runTask('require("nice-napi")()');
+
+  // niceness is capped to 19 on Linux.
+  const expected = Math.min(currentNiceness + 5, 19);
+  is(result, expected);
+});
+
+test('setting niceness never does anything bad', async ({ is }) => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    niceIncrement: 5
+  });
+
+  const result = await worker.runTask('42');
+  is(result, 42);
+});

--- a/test/option-validation.ts
+++ b/test/option-validation.ts
@@ -101,3 +101,13 @@ test('taskQueue must be a TaskQueue object', async ({ throws }) => {
     taskQueue: { } as any
   }) as any), /options.taskQueue must be a TaskQueue object/);
 });
+
+test('niceIncrement must be non-negative integer', async ({ throws }) => {
+  throws(() => new Piscina(({
+    niceIncrement: -1
+  }) as any), /options.niceIncrement must be a non-negative integer/);
+
+  throws(() => new Piscina(({
+    niceIncrement: 'string'
+  }) as any), /options.niceIncrement must be a non-negative integer/);
+});


### PR DESCRIPTION
The OS restriction is due to the fact that macOS does not provide
per-thread priority values.